### PR TITLE
Disable Clear of oderbys

### DIFF
--- a/Source/Linq/Builder/OrderByBuilder.cs
+++ b/Source/Linq/Builder/OrderByBuilder.cs
@@ -50,8 +50,8 @@ namespace LinqToDB.Linq.Builder
 
 			builder.ReplaceParent(order, sparent);
 
-			if (!methodCall.Method.Name.StartsWith("Then"))
-				sequence.SelectQuery.OrderBy.Items.Clear();
+			//if (!methodCall.Method.Name.StartsWith("Then"))
+			//	sequence.SelectQuery.OrderBy.Items.Clear();
 
 			foreach (var expr in sql)
 			{


### PR DESCRIPTION
If you hav nested Queryables, your object may become a Iqueryable again so you cannot use ThenBy. So don't clear orderbys